### PR TITLE
Fix bug in needle endweight False mode

### DIFF
--- a/nucleus/embaln.c
+++ b/nucleus/embaln.c
@@ -406,6 +406,10 @@ float embAlignPathCalcWithEndGapPenalties(const char *a, const char *b,
             if(xpos==lenb)
             {
         	testog = m[++cursorp] - endgapopen;
+            	
+            if (testog<ix[cursorp]-endgapopen)
+                testog = ix[cursorp]-endgapopen;
+            	
         	testeg = iy[cursorp] - endgapextend;
             }
             else
@@ -430,6 +434,10 @@ float embAlignPathCalcWithEndGapPenalties(const char *a, const char *b,
             if(ypos==lena)
             {
         	testog = m[--cursorp] - endgapopen;
+            	
+            if (testog<iy[cursorp]-endgapopen)
+                testog = iy[cursorp]-endgapopen;
+            	
         	testeg = ix[cursorp] - endgapextend;
             }
             else


### PR DESCRIPTION

in
nucleus/embaln.c


1.
Because of the line 317,
endweight is set as ajTrue,
the alignment always starts from (lena-1, lenb-1).
even if endweight was False at first.


2.
In the score calculation step, around line 406, and 430,
if xpos == lenb or ypos == lena (last column or row),
the path insertx -> inserty or inserty-> insertx was not created.


3.
However, in the backtracking step from line 507, such a restriction is
not considered.
insertx -> inserty or inserty-> insertx would occur.


4.
Therefore, the resulting backtrack path sometimes does not reflect the
path which produced the value in the variable "score".



I attached an example as needle.dbg.txt
[needle.dbg.txt](https://github.com/kimrutherford/EMBOSS/files/5286804/needle.dbg.txt)
 which I was going to align
&gt;s1
AAAAAAAAAAAAAAAAILEEEEEEEEEE
&gt;s2
AAAAAAAAAAAAAAAAFFCCCCCCCCCC

The command is
emboss/needle -asequence testseqa2.fas -bsequence testseqb2.fas
-gapopen 10.0 -gapextend 0.5 -out testoutb.dat -datafile EBLOSUM62
-sprotein1 -sprotein2 -debug
(the code was a bit modified to print dp matrix)

The environment is
Ubuntu 16.04
Running on Oracle Virtual Box.


The alignment which produces the score 48.5 must be
&gt;s1
AAAAAAAAAAAAAAAAI----------LEEEEEEEEEE
&gt;s2
AAAAAAAAAAAAAAAAFFCCCCCCCCCC----------


However, the alignment proposed by needle is
&gt;s1
AAAAAAAAAAAAAAAAIL----------EEEEEEEEEE
&gt;s2
AAAAAAAAAAAAAAAAFFCCCCCCCCCC----------


