### PR TITLE
long time bug in dotmatcher. Seqs were not displayed as they were nam…

### DIFF
--- a/emboss/dotmatcher.c
+++ b/emboss/dotmatcher.c
@@ -144,8 +144,8 @@ int main(int argc, char **argv)
 
     embInit("dotmatcher", argc, argv);
     
-    seq2       = ajAcdGetSeq("asequence");
-    seq        = ajAcdGetSeq("bsequence");
+    seq       = ajAcdGetSeq("asequence");
+    seq2        = ajAcdGetSeq("bsequence");
     stretch    = ajAcdGetToggle("stretch");
     graph      = ajAcdGetGraph("graph");
     xygraph    = ajAcdGetGraphxy("xygraph");


### PR DESCRIPTION
…ed. Convince your self by trying two sequences of obviously different sizes